### PR TITLE
Remove usage of Sidekiq::Util

### DIFF
--- a/lib/sidekiq/process_manager/manager.rb
+++ b/lib/sidekiq/process_manager/manager.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
 require "sidekiq"
-require "sidekiq/util"
 
 module Sidekiq
   module ProcessManager
     class Manager
-      include Sidekiq::Util
-
       attr_reader :cli
 
       def initialize(process_count: 1, prefork: false, preboot: nil, mode: nil, silent: false)
@@ -58,7 +55,9 @@ module Sidekiq
           end
         end
 
-        @signal_thread = safe_thread("signal_handler") do
+        @signal_thread = Thread.new do
+          Thread.current.name = "signal_handler"
+
           while signal_pipe_read.wait_readable
             signal = signal_pipe_read.gets.strip
             send_signal_to_children(signal.to_sym)


### PR DESCRIPTION
Sidekiq::Util was removed in 6.5.0. I originally used it for the thread
creation method `safe_thread` but it's easy enough to create the thread
and not rely on Sidekiq internals.