### PR TITLE
Remove tags from logs

### DIFF
--- a/lib/sidekiq/process_manager/manager.rb
+++ b/lib/sidekiq/process_manager/manager.rb
@@ -163,8 +163,7 @@ module Sidekiq
       end
 
       def set_program_name!
-        tag = SIDEKIQ_GTE_6_5_0 ? Sidekiq[:tag] : Sidekiq.options[:tag]
-        $PROGRAM_NAME = "sidekiq process manager #{tag} [#{@pids.size} processes]"
+        $PROGRAM_NAME = "sidekiq process manager [#{@pids.size} processes]"
       end
 
       def start_child_process!


### PR DESCRIPTION
`Sidekiq[:tag]` and `Sidekiq.options[:tag]` no longer works in sidekiq 7 because options are no longer global.
https://github.com/mperham/sidekiq/blob/main/docs/capsule.md